### PR TITLE
Disable non-security dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  # Enable version updates for npm
-  - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
-    directory: '/'
-    # Check the npm registry for updates every day (weekdays)
-    schedule:
-      interval: 'daily'


### PR DESCRIPTION
We still receive security updates as configured in the Github UI (as per https://stackoverflow.com/a/64145646)